### PR TITLE
ENG-561 Issue Renaming Buckets

### DIFF
--- a/src/api/models/bucket.rs
+++ b/src/api/models/bucket.rs
@@ -167,7 +167,11 @@ impl Bucket {
     /// Update the bucket fields. Puts the current local values against the current remote values.
     /// For now only updates to 'name' will be processed, all others will be ignored
     pub async fn update(&self, client: &mut Client) -> Result<(), ApiError> {
-        let update_request = UpdateBucket(self.clone());
+        let update_request = UpdateBucket {
+            bucket_id: String::from(self.id),
+            name: self.name.clone(),
+        };
+
         client.call_no_content(update_request).await
     }
 

--- a/src/api/requests/core/buckets/update.rs
+++ b/src/api/requests/core/buckets/update.rs
@@ -2,11 +2,13 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 
 use reqwest::{Client, RequestBuilder, Url};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api::requests::ApiRequest;
 
+#[derive(Serialize)]
 pub struct UpdateBucket {
+    #[serde(skip)]
     pub bucket_id: String,
     pub name: String,
 }
@@ -23,7 +25,7 @@ impl ApiRequest for UpdateBucket {
             .join(&format!("/api/v1/buckets/{}", self.bucket_id))
             .unwrap();
 
-        client.put(url).json(&self.name)
+        client.put(url).json(&self)
     }
 
     fn requires_authentication(&self) -> bool {

--- a/src/api/requests/core/buckets/update.rs
+++ b/src/api/requests/core/buckets/update.rs
@@ -4,9 +4,12 @@ use std::fmt::{self, Display, Formatter};
 use reqwest::{Client, RequestBuilder, Url};
 use serde::Deserialize;
 
-use crate::api::{models::bucket::Bucket, requests::ApiRequest};
+use crate::api::requests::ApiRequest;
 
-pub struct UpdateBucket(pub Bucket);
+pub struct UpdateBucket {
+    pub bucket_id: String,
+    pub name: String,
+}
 
 #[derive(Deserialize)]
 pub struct UpdateBucketResponse;
@@ -17,9 +20,10 @@ impl ApiRequest for UpdateBucket {
 
     fn build_request(self, base_url: &Url, client: &Client) -> RequestBuilder {
         let url = base_url
-            .join(&format!("/api/v1/buckets/{}", self.0.id))
+            .join(&format!("/api/v1/buckets/{}", self.bucket_id))
             .unwrap();
-        client.put(url).json(&self.0)
+
+        client.put(url).json(&self.name)
     }
 
     fn requires_authentication(&self) -> bool {


### PR DESCRIPTION
Tiny modification to the api submodule which alters the api request sent on bucket updating to match that of the core service as per [this ticket](https://linear.app/banyan/issue/ENG-561/issue-renaming-buckets).