### PR TITLE
Vera / Improve WASM Logging

### DIFF
--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -350,18 +350,19 @@ impl TombWasm {
         bucket_id: String,
         encryption_key_pem: String,
     ) -> TombResult<WasmMount> {
-        info!("mount()/{}", &bucket_id);
+        let prefix = format!("mount()/{}", bucket_id);
+        info!(prefix);
 
         // Parse the bucket id
         let bucket_id_uuid =
             Uuid::parse_str(&bucket_id).map_err(to_wasm_error_with_msg("parse UUID"))?;
-        info!("mount()/{}/reading key pair", &bucket_id);
+        info!("{}: reading key pair", prefix);
 
         // Load the EcEncryptionKey
         let key = EcEncryptionKey::import(encryption_key_pem.as_bytes())
             .await
             .map_err(to_wasm_error_with_msg("import encryption key"))?;
-        info!("mount()/{}/reading bucket", &bucket_id);
+        info!("{}: reading bucket", prefix);
 
         // Load the bucket
         let bucket: WasmBucket = Bucket::read(self.client(), bucket_id_uuid)
@@ -369,13 +370,15 @@ impl TombWasm {
             .map_err(to_wasm_error_with_msg("read bucket"))?
             .into();
 
-        info!("mount()/{}/pulling mount", &bucket_id);
+        let prefix = format!("mount()/{}", bucket.name());
+
+        info!("{}: pulling mount", prefix);
 
         // Get the bucket id
         // Try to pull the mount. Otherwise create it and push an initial piece of metadata
         let mount = match WasmMount::pull(bucket.clone(), self.client()).await {
             Ok(mut mount) => {
-                info!("mount()/{}/pulled mount, unlocking", &bucket_id);
+                info!("{}: pulled mount, unlocking", prefix);
 
                 // Unlock the mount
                 let unlock_result = mount.unlock(&key).await;
@@ -386,14 +389,14 @@ impl TombWasm {
 
                 // Check the result
                 match unlock_result {
-                    Ok(_) => info!("mount()/{}/unlocked mount", &bucket_id),
-                    Err(_) => info!("mount()/{}/could not unlock mount", &bucket_id),
+                    Ok(_) => info!("{}: unlocked mount", prefix),
+                    Err(_) => info!("{}: could not unlock mount", prefix),
                 };
 
                 mount
             }
             Err(err) => {
-                error!("mount()/{}/failure to pull mount: {}", &bucket_id, err);
+                error!("{}: failure to pull mount: {}", prefix, err);
                 return Err(err.into());
             }
         };

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -351,7 +351,7 @@ impl TombWasm {
         encryption_key_pem: String,
     ) -> TombResult<WasmMount> {
         let prefix = format!("mount()/{}", bucket_id);
-        info!(prefix);
+        info!("{prefix}");
 
         // Parse the bucket id
         let bucket_id_uuid =

--- a/src/wasm/compat/types/mount.rs
+++ b/src/wasm/compat/types/mount.rs
@@ -64,7 +64,7 @@ impl WasmMount {
         client: &Client,
     ) -> Result<Self, TombWasmError> {
         let prefix = format!("new()/{}", wasm_bucket.name());
-        info!(prefix);
+        info!("{prefix}");
 
         let bucket = Bucket::from(wasm_bucket.clone());
         info!("{}: creating blockstores", prefix);
@@ -105,7 +105,7 @@ impl WasmMount {
     /// Initialize a new Wasm callable mount with metadata for a bucket and a client
     pub async fn pull(wasm_bucket: WasmBucket, client: &mut Client) -> Result<Self, TombWasmError> {
         let prefix = format!("pull()/{}", wasm_bucket.name());
-        info!(prefix);
+        info!("{prefix}");
         // Get the underlying bucket
         let bucket = Bucket::from(wasm_bucket.clone());
 
@@ -154,7 +154,7 @@ impl WasmMount {
     /// Refresh the current fs_metadata with the remote
     pub async fn refresh(&mut self, key: &EcEncryptionKey) -> Result<(), TombWasmError> {
         let prefix = format!("refresh()/{}", self.bucket.name);
-        info!(prefix);
+        info!("{prefix}");
 
         let bucket_id = self.bucket.id;
         // Get the metadata associated with the bucket
@@ -205,7 +205,7 @@ impl WasmMount {
     /// Sync the current fs_metadata with the remote
     pub async fn sync(&mut self) -> Result<(), TombWasmError> {
         let prefix = format!("sync()/{}", self.bucket.name);
-        info!(prefix);
+        info!("{prefix}");
         // Check if the bucket is locked
         if self.locked() {
             info!("{}: bucket is locked", prefix);
@@ -322,7 +322,7 @@ impl WasmMount {
     /// Unlock the current fs_metadata
     pub async fn unlock(&mut self, key: &EcEncryptionKey) -> Result<(), TombWasmError> {
         let prefix = format!("unlock()/{}", self.bucket.name);
-        info!(prefix);
+        info!("{prefix}");
 
         // Check if the bucket is already unlocked
         if !self.locked() {
@@ -432,7 +432,7 @@ impl WasmMount {
             .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         let prefix = format!("ls()/{}/{}", self.bucket.name, &path_segments.join("/"));
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             return Err(
@@ -485,7 +485,7 @@ impl WasmMount {
             .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         let prefix = format!("mkdir()/{}/{}", self.bucket.name, &path_segments.join("/"));
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             panic!("Bucket is locked");
@@ -509,7 +509,7 @@ impl WasmMount {
     /// Refreshes the bucket to ensure its up to date against what the server is aware of
     pub async fn remount(&mut self, encryption_key_pem: String) -> TombResult<()> {
         let prefix = format!("remount()/{}", self.bucket.name);
-        info!(prefix);
+        info!("{prefix}");
 
         let key = EcEncryptionKey::import(encryption_key_pem.as_bytes())
             .await
@@ -544,7 +544,7 @@ impl WasmMount {
             .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         let prefix = format!("write()/{}/{}", self.bucket.name, &path_segments.join("/"));
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             panic!("Bucket is locked");
@@ -598,7 +598,7 @@ impl WasmMount {
             self.bucket.name,
             &path_segments.join("/")
         );
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             panic!("Bucket is locked");
@@ -675,7 +675,7 @@ impl WasmMount {
             &from_path_segments.join("/"),
             &to_path_segments.join("/")
         );
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             panic!("Bucket is locked");
@@ -722,7 +722,7 @@ impl WasmMount {
             .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         let prefix = format!("rm()/{}/{}", self.bucket.name, path_segments.join("/"));
-        info!(prefix);
+        info!("{prefix}");
 
         if self.locked() {
             panic!("Bucket is locked");
@@ -776,7 +776,7 @@ impl WasmMount {
     #[wasm_bindgen(js_name = shareWith)]
     pub async fn share_with(&mut self, bucket_key_id: String) -> TombResult<()> {
         let prefix = format!("share_with/{}/{}", self.bucket.name, bucket_key_id.clone());
-        info!(prefix);
+        info!("{prefix}");
         let bucket_id = self.bucket.id;
         let bucket_key_id =
             uuid::Uuid::parse_str(&bucket_key_id).map_err(to_wasm_error_with_msg("parse UUID"))?;
@@ -821,7 +821,7 @@ impl WasmMount {
             self.bucket.name,
             &path_segments.join("/")
         );
-        info!(prefix);
+        info!("{prefix}");
 
         // Read the array as a Vec<String>
         let path_segments = path_segments


### PR DESCRIPTION
While investigating [this issue](https://linear.app/banyan/issue/ENG-561/issue-renaming-buckets), i noticed  some of the logs to be less than legible, with highly redundant code.
- modifies logs to be more legible, using the already unique bucket names rather than bucket ids.
- maintains consistency between logs in individual fns
- makes modifying logs easier